### PR TITLE
feat: implemente logica para responder preguntas y sesiones de test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.hypersistence</groupId>
+            <artifactId>hypersistence-utils-hibernate-60</artifactId>
+            <version>3.7.0</version>
+        </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>

--- a/src/main/java/com/vocatio/controller/TestController.java
+++ b/src/main/java/com/vocatio/controller/TestController.java
@@ -1,0 +1,38 @@
+package com.vocatio.controller;
+
+import com.vocatio.dto.request.SubmitAnswerRequestDTO;
+import com.vocatio.dto.response.PreguntaDTO;
+import com.vocatio.dto.response.StartTestResponseDTO;
+import com.vocatio.service.TestService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/tests")
+public class TestController {
+
+    private final TestService testService;
+
+    public TestController(TestService testService) {
+        this.testService = testService;
+    }
+
+    @PostMapping("/{testId}/iniciar")
+    public ResponseEntity<StartTestResponseDTO> iniciarTest(@PathVariable Long testId, @RequestParam Long userId) {
+        StartTestResponseDTO response = testService.iniciarTest(testId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/sessions/{sessionId}/answers")
+    public ResponseEntity<PreguntaDTO> submitAnswer(
+            @PathVariable Long sessionId,
+            @RequestBody SubmitAnswerRequestDTO answerRequest) {
+        PreguntaDTO nextQuestion = testService.submitAnswerAndGetNext(sessionId, answerRequest);
+
+        if (nextQuestion != null) {
+            return ResponseEntity.ok(nextQuestion);
+        } else {
+            return ResponseEntity.ok().build();
+        }
+    }
+}

--- a/src/main/java/com/vocatio/dto/request/SubmitAnswerRequestDTO.java
+++ b/src/main/java/com/vocatio/dto/request/SubmitAnswerRequestDTO.java
@@ -1,0 +1,9 @@
+package com.vocatio.dto.request;
+
+import lombok.Data;
+
+@Data
+public class SubmitAnswerRequestDTO {
+    private Long preguntaId;
+    private Long opcionId;
+}

--- a/src/main/java/com/vocatio/dto/response/OpcionDTO.java
+++ b/src/main/java/com/vocatio/dto/response/OpcionDTO.java
@@ -1,0 +1,9 @@
+package com.vocatio.dto.response;
+
+import lombok.Data;
+
+@Data
+public class OpcionDTO {
+    private Long id;
+    private String textoOpcion;
+}

--- a/src/main/java/com/vocatio/dto/response/PreguntaDTO.java
+++ b/src/main/java/com/vocatio/dto/response/PreguntaDTO.java
@@ -1,0 +1,12 @@
+package com.vocatio.dto.response;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class PreguntaDTO {
+    private Long id;
+    private String textoPregunta;
+    private String progreso; // Ej: "Pregunta 2 de 30"
+    private List<OpcionDTO> opciones;
+}

--- a/src/main/java/com/vocatio/dto/response/StartTestResponseDTO.java
+++ b/src/main/java/com/vocatio/dto/response/StartTestResponseDTO.java
@@ -1,0 +1,9 @@
+package com.vocatio.dto.response;
+
+import lombok.Data;
+
+@Data
+public class StartTestResponseDTO {
+    private Long sessionId;
+    private PreguntaDTO primeraPregunta;
+}

--- a/src/main/java/com/vocatio/model/AreasInteres.java
+++ b/src/main/java/com/vocatio/model/AreasInteres.java
@@ -1,0 +1,14 @@
+package com.vocatio.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Table(name = "areas_interes")
+@Data
+public class AreasInteres {
+    @Id
+    private String id; // "R", "I", "A", "S", "E", "C"
+    private String nombre;
+    private String descripcion;
+}

--- a/src/main/java/com/vocatio/model/Opcion.java
+++ b/src/main/java/com/vocatio/model/Opcion.java
@@ -1,0 +1,22 @@
+package com.vocatio.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Table(name = "opciones")
+@Data
+public class Opcion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String textoOpcion;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_pregunta")
+    private Pregunta pregunta;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_area_interes")
+    private AreasInteres areaInteres;
+}

--- a/src/main/java/com/vocatio/model/Pregunta.java
+++ b/src/main/java/com/vocatio/model/Pregunta.java
@@ -1,0 +1,23 @@
+package com.vocatio.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.util.List;
+
+@Entity
+@Table(name = "preguntas")
+@Data
+public class Pregunta {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String textoPregunta;
+    private int orden;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_test")
+    private Test test;
+
+    @OneToMany(mappedBy = "pregunta", cascade = CascadeType.ALL)
+    private List<Opcion> opciones;
+}

--- a/src/main/java/com/vocatio/model/Test.java
+++ b/src/main/java/com/vocatio/model/Test.java
@@ -1,0 +1,18 @@
+package com.vocatio.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.util.List;
+
+@Entity
+@Table(name = "tests_vocacionales")
+@Data
+public class Test {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String titulo;
+
+    @OneToMany(mappedBy = "test", fetch = FetchType.EAGER)
+    private List<Pregunta> preguntas;
+}

--- a/src/main/java/com/vocatio/model/TestSession.java
+++ b/src/main/java/com/vocatio/model/TestSession.java
@@ -1,0 +1,35 @@
+package com.vocatio.model;
+
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.Type;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@Entity
+@Table(name = "test_sessions")
+@Data
+public class TestSession {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "id_usuario")
+    private Usuario usuario;
+
+    @ManyToOne
+    @JoinColumn(name = "id_test")
+    private Test test;
+
+    private String estado;
+
+    @Type(JsonType.class)
+    @Column(columnDefinition = "jsonb")
+    private Map<Long, Long> respuestas = new HashMap<>();
+
+    private LocalDateTime iniciadoEn = LocalDateTime.now();
+    private LocalDateTime completadoEn;
+}

--- a/src/main/java/com/vocatio/repository/AreasInteresRepository.java
+++ b/src/main/java/com/vocatio/repository/AreasInteresRepository.java
@@ -1,0 +1,7 @@
+package com.vocatio.repository;
+
+import com.vocatio.model.AreasInteres;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AreasInteresRepository extends JpaRepository<AreasInteres, String> {
+}

--- a/src/main/java/com/vocatio/repository/OpcionRepository.java
+++ b/src/main/java/com/vocatio/repository/OpcionRepository.java
@@ -1,0 +1,7 @@
+package com.vocatio.repository;
+
+import com.vocatio.model.Opcion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OpcionRepository extends JpaRepository<Opcion, Long> {
+}

--- a/src/main/java/com/vocatio/repository/PreguntaRepository.java
+++ b/src/main/java/com/vocatio/repository/PreguntaRepository.java
@@ -1,0 +1,9 @@
+package com.vocatio.repository;
+
+import com.vocatio.model.Pregunta;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface PreguntaRepository extends JpaRepository<Pregunta, Long> {
+    Optional<Pregunta> findByTestIdAndOrden(Long testId, int orden);
+}

--- a/src/main/java/com/vocatio/repository/TestRepository.java
+++ b/src/main/java/com/vocatio/repository/TestRepository.java
@@ -1,0 +1,7 @@
+package com.vocatio.repository;
+
+import com.vocatio.model.Test;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TestRepository extends JpaRepository<Test, Long> {
+}

--- a/src/main/java/com/vocatio/repository/TestSessionRepository.java
+++ b/src/main/java/com/vocatio/repository/TestSessionRepository.java
@@ -1,0 +1,7 @@
+package com.vocatio.repository;
+
+import com.vocatio.model.TestSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TestSessionRepository extends JpaRepository<TestSession, Long> {
+}

--- a/src/main/java/com/vocatio/service/TestService.java
+++ b/src/main/java/com/vocatio/service/TestService.java
@@ -1,0 +1,110 @@
+package com.vocatio.service;
+
+import com.vocatio.dto.request.SubmitAnswerRequestDTO;
+import com.vocatio.dto.response.OpcionDTO;
+import com.vocatio.dto.response.PreguntaDTO;
+import com.vocatio.dto.response.StartTestResponseDTO;
+import com.vocatio.model.Opcion;
+import com.vocatio.model.Pregunta;
+import com.vocatio.model.Test;
+import com.vocatio.model.TestSession;
+import com.vocatio.model.Usuario;
+import com.vocatio.repository.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+
+@Service
+public class TestService {
+
+    private final TestRepository testRepository;
+    private final PreguntaRepository preguntaRepository;
+    private final UsuarioRepository usuarioRepository;
+    private final TestSessionRepository testSessionRepository;
+    private final OpcionRepository opcionRepository;
+
+    public TestService(TestRepository testRepository, PreguntaRepository preguntaRepository, UsuarioRepository usuarioRepository, TestSessionRepository testSessionRepository, OpcionRepository opcionRepository) {
+        this.testRepository = testRepository;
+        this.preguntaRepository = preguntaRepository;
+        this.usuarioRepository = usuarioRepository;
+        this.testSessionRepository = testSessionRepository;
+        this.opcionRepository = opcionRepository;
+    }
+
+    @Transactional
+    public StartTestResponseDTO iniciarTest(Long testId, Long userId) {
+        Usuario usuario = usuarioRepository.findById(userId).orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+        Test test = testRepository.findById(testId).orElseThrow(() -> new RuntimeException("Test no encontrado"));
+
+        TestSession newSession = new TestSession();
+        newSession.setUsuario(usuario);
+        newSession.setTest(test);
+        newSession.setEstado("IN_PROGRESS");
+        TestSession savedSession = testSessionRepository.save(newSession);
+
+        Pregunta primeraPregunta = preguntaRepository.findByTestIdAndOrden(testId, 1)
+                .orElseThrow(() -> new RuntimeException("No se encontró la primera pregunta para el test"));
+
+        StartTestResponseDTO response = new StartTestResponseDTO();
+        response.setSessionId(savedSession.getId());
+        response.setPrimeraPregunta(convertirAPreguntaDTO(primeraPregunta));
+        return response;
+    }
+
+    @Transactional
+    public PreguntaDTO submitAnswerAndGetNext(Long sessionId, SubmitAnswerRequestDTO answerRequest) {
+        Long preguntaId = answerRequest.getPreguntaId();
+        Long opcionId = answerRequest.getOpcionId();
+
+        TestSession session = testSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new RuntimeException("Sesión de test no encontrada"));
+
+        if (!"IN_PROGRESS".equals(session.getEstado())) {
+            throw new RuntimeException("Este test ya ha sido completado.");
+        }
+
+        Opcion opcionSeleccionada = opcionRepository.findById(opcionId)
+                .orElseThrow(() -> new IllegalArgumentException("La opción con id " + opcionId + " no es válida."));
+
+        if (!opcionSeleccionada.getPregunta().getId().equals(preguntaId)) {
+            throw new IllegalArgumentException("La opción seleccionada no pertenece a la pregunta actual.");
+        }
+
+        session.getRespuestas().put(preguntaId, opcionId);
+
+        int currentOrder = session.getRespuestas().size();
+        int nextOrder = currentOrder + 1;
+
+        var nextQuestionOpt = preguntaRepository.findByTestIdAndOrden(session.getTest().getId(), nextOrder);
+
+        if (nextQuestionOpt.isPresent()) {
+            testSessionRepository.save(session);
+            return convertirAPreguntaDTO(nextQuestionOpt.get());
+        } else {
+            session.setEstado("COMPLETED");
+            session.setCompletadoEn(LocalDateTime.now());
+            testSessionRepository.save(session);
+            return null;
+        }
+    }
+
+    private PreguntaDTO convertirAPreguntaDTO(Pregunta pregunta) {
+        PreguntaDTO dto = new PreguntaDTO();
+        dto.setId(pregunta.getId());
+        dto.setTextoPregunta(pregunta.getTextoPregunta());
+
+        int totalPreguntas = pregunta.getTest().getPreguntas().size();
+        dto.setProgreso("Pregunta " + pregunta.getOrden() + " de " + totalPreguntas);
+
+        dto.setOpciones(pregunta.getOpciones().stream().map(opcion -> {
+            OpcionDTO opcionDTO = new OpcionDTO();
+            opcionDTO.setId(opcion.getId());
+            opcionDTO.setTextoOpcion(opcion.getTextoOpcion());
+            return opcionDTO;
+        }).collect(Collectors.toList()));
+
+        return dto;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,8 @@ server.servlet.context-path=/api/v1
 #PostgreSQL database configuration
 spring.datasource.url=jdbc:postgresql://localhost:5432/vocatio
 spring.datasource.username=postgres
-spring.datasource.password=admin
+spring.datasource.password=ADMIN
+
 spring.datasource.driver-class-name=org.postgresql.Driver
 #JPA configurations
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
Funcionalidad para iniciar y resolver un test vocacional.

- Se crearon las nuevas tablas en la base de datos: 'areas_interes', 'tests_vocacionales', 'preguntas', 'opciones' y 'test_sessions'.
- Se agregó la nueva funcionalidad a los paquetes 'model', 'dto', 'repository', 'service' y 'controller'.
- Las nuevas rutas (mappings) son:
  - POST /tests/{testId}/iniciar
  - POST /tests/sessions/{sessionId}/answers